### PR TITLE
CI: Add Cargo dependents cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable-msvc
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -40,6 +39,16 @@ jobs:
           cache: 'pnpm'
       - name: Build
         run: sh ci/install-choco.sh
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Archive Build Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yaml` file to improve the build process by introducing caching for Rust's Cargo.

### Workflow Improvements:
* Added a new `Cache Cargo` step using `actions/cache@v4` to cache Cargo binaries, registry data, and build artifacts, which helps speed up subsequent builds.